### PR TITLE
(#26): Update button navigation and add SignIn/Signup stacks

### DIFF
--- a/navigation/index.tsx
+++ b/navigation/index.tsx
@@ -7,8 +7,8 @@ import { createStackNavigator } from "@react-navigation/stack";
 import * as React from "react";
 import { ColorSchemeName } from "react-native";
 // import HomeScreen from "../screens/HomeScreen";
-// import SignInScreen from "../screens/SignInScreen";
-// import SignUpScreen from "../screens/SignUpScreen";
+import SignInScreen from "../screens/SignInScreen";
+import SignUpScreen from "../screens/SignUpScreen";
 
 import NotFoundScreen from "../screens/NotFoundScreen";
 import { RootStackParamList } from "../types";
@@ -44,6 +44,16 @@ function RootNavigator() {
         name="NotFound"
         component={NotFoundScreen}
         options={{ title: "Oops!" }}
+      />
+      <Stack.Screen
+        name="SignIn"
+        component={SignInScreen}
+        options={{ title: "Sign in" }}
+      />
+      <Stack.Screen
+        name="SignUp"
+        component={SignUpScreen}
+        options={{ title: "Sign up" }}
       />
     </Stack.Navigator>
   );

--- a/screens/HomeScreen.tsx
+++ b/screens/HomeScreen.tsx
@@ -25,14 +25,14 @@ export default function HomeScreen({
           <Button
             style={styles.button}
             mode="contained"
-            onPress={() => navigation.replace("Root")}
+            onPress={() => navigation.replace("SignIn")}
           >
             Sign-In
           </Button>
           <Button
             style={styles.button}
             mode="contained"
-            onPress={() => navigation.replace("Root")}
+            onPress={() => navigation.replace("SignUp")}
           >
             Sign-Up
           </Button>

--- a/screens/SignInScreen.tsx
+++ b/screens/SignInScreen.tsx
@@ -64,7 +64,7 @@ const styles = StyleSheet.create({
   },
   textInput: {
     minWidth: 200,
-    height: 64,
+    maxHeight: 64,
     justifyContent: "center",
     marginBottom: 8,
   },

--- a/screens/SignUpScreen.tsx
+++ b/screens/SignUpScreen.tsx
@@ -76,7 +76,7 @@ const styles = StyleSheet.create({
   },
   textInput: {
     minWidth: 200,
-    height: 64,
+    maxHeight: 64,
     justifyContent: "center",
     marginBottom: 8,
   },

--- a/screens/SignUpScreen.tsx
+++ b/screens/SignUpScreen.tsx
@@ -1,8 +1,10 @@
+import {StackScreenProps} from "@react-navigation/stack";
 import React, { useState } from "react";
 import { StyleSheet, Text, View } from "react-native";
 import { Button, TextInput } from "react-native-paper";
+import {RootStackParamList} from "../types";
 
-export default function SignUpScreen({ navigation }) {
+export default function SignUpScreen({ navigation }: StackScreenProps<RootStackParamList, "SignUp">) {
   const [username, setUsername] = useState("");
   const [password, setPassword] = useState("");
 
@@ -40,7 +42,7 @@ export default function SignUpScreen({ navigation }) {
         <Button
           style={styles.button}
           mode="contained"
-          onPress={() => navigation.navigate("Home")}
+          onPress={() => navigation.navigate("Root")}
         >
           Sign-Up!
         </Button>
@@ -49,7 +51,7 @@ export default function SignUpScreen({ navigation }) {
   );
 }
 
-SignInScreen.navigationOptions = {
+SignUpScreen.navigationOptions = {
   header: null,
 };
 

--- a/types.tsx
+++ b/types.tsx
@@ -1,6 +1,8 @@
 export type RootStackParamList = {
   Root: undefined;
   NotFound: undefined;
+  SignIn: undefined;
+  SignUp: undefined;
 };
 
 export type BottomTabParamList = {


### PR DESCRIPTION
Closes #26 

## Changes Proposed in this Pull Request:
- Updated the navigator mappings `"SignIn" -> SignInScreen` and `"SignUp" -> SignUpScreen`
- Updated the buttons to navigate to `SignIn` and `SignUp` respectively

@BekahHW
